### PR TITLE
feat(desktop): add Terax AI terminal

### DIFF
--- a/features/window-manager/terax/default.nix
+++ b/features/window-manager/terax/default.nix
@@ -1,0 +1,14 @@
+# Terax - AI-native terminal (Tauri): https://github.com/crynta/terax-ai
+{
+  pkgs,
+  lib,
+  ...
+}: {
+  environment = {
+    systemPackages = lib.optional (pkgs.stdenv.hostPlatform.system == "x86_64-linux") (
+      pkgs.callPackage ./package.nix {
+        gdk_pixbuf = pkgs."gdk-pixbuf";
+      }
+    );
+  };
+}

--- a/features/window-manager/terax/package.nix
+++ b/features/window-manager/terax/package.nix
@@ -1,0 +1,64 @@
+# Terax upstream release (deb): https://github.com/crynta/terax-ai/releases
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  gtk3,
+  libsoup_3,
+  cairo,
+  gdk_pixbuf,
+  glib,
+}:
+stdenv.mkDerivation rec {
+  pname = "terax";
+  version = "0.5.9";
+
+  src = fetchurl {
+    url = "https://github.com/crynta/terax-ai/releases/download/v${version}/Terax_${version}_amd64.deb";
+    hash = "sha256-0mSHIdT9UHfryYMdxT3R2M+FOCjbX2oYLReBRFk78N4=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+    libsoup_3
+    cairo
+    gdk_pixbuf
+    glib
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src source
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r source/usr/* $out/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lightweight AI-native terminal (ADE) built with Tauri";
+    homepage = "https://github.com/crynta/terax-ai";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
+    platforms = ["x86_64-linux"];
+    mainProgram = "terax";
+  };
+}

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -17,6 +17,7 @@
     ../features/window-manager/gnome
     ../features/window-manager/hyprland
     ../features/window-manager/kitty
+    ../features/window-manager/terax
     ../features/window-manager/stylix
     ../features/window-manager/xclip
     ../features/window-manager/xfce-screenshooter


### PR DESCRIPTION
Package upstream amd64 .deb (v0.5.9) with autoPatchelf and GTK/WebKit wrapping. Install only on x86_64-linux and enable via the desktop profile.

Upstream: https://github.com/crynta/terax-ai