### PR TITLE
chore(profiles): disable Solana in crypto profile

### DIFF
--- a/profiles/crypto.nix
+++ b/profiles/crypto.nix
@@ -11,6 +11,6 @@
   imports = [
     ../features/crypto/bisq
     ../features/crypto/monero
-    ../features/crypto/solana
+    #../features/crypto/solana
   ];
 }


### PR DESCRIPTION
Comment out the solana feature import so the crypto profile stays lean until it is needed again.